### PR TITLE
Making my emulators happy

### DIFF
--- a/magneto/__init__.py
+++ b/magneto/__init__.py
@@ -154,6 +154,18 @@ class Magneto(threading.local, AutomatorDevice):
                 break
             yield selector
 
+    def screenshot(self, filename, scale=1.0, quality=100):
+        """take screenshot. overrides AutomatorDevice screenshot method in order
+        to use adb shell screencap instead of jsonrpc.takeScreenshot (works better on emulators)"""
+        device_file = "/mnt/sdcard/screenshot.png"
+        try:
+            screencap = self.server.adb.cmd("shell", "screencap", "-p", device_file)
+            screencap.wait()
+            pull = self.server.adb.cmd("pull", device_file, filename)
+            pull.wait()
+        finally:
+            self.server.adb.cmd("shell", "rm", device_file).wait()
+        return filename if pull.returncode is 0 else None
 
 class MagnetoDeviceObject(AutomatorDeviceObject):
     def __init__(self, device, selector):

--- a/magneto/main.py
+++ b/magneto/main.py
@@ -5,6 +5,7 @@ import os
 import pytest
 
 from . import Magneto
+import sys
 from .logger import Logger
 from .base import BaseTestCase
 from .utils import ADB, wait_for_device, unlock_device
@@ -80,7 +81,8 @@ def main(log):
 @click.argument('tests_path', default='.')
 @click.pass_context
 def run(ctx, tests_path):
-    pytest.main(['-sv', tests_path] + ctx.args, plugins=[MagnetoPlugin()])
+    error_code = pytest.main(['-sv', tests_path] + ctx.args, plugins=[MagnetoPlugin()])
+    sys.exit(error_code)
 
 
 @main.command(context_settings=dict(

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='magneto',
-    version='0.37',
+    version='0.38',
     description='Magneto - Test Automation for Android',
     author='EverythingMe',
     author_email='automation@everything.me',


### PR DESCRIPTION
Proposing two fixes :
1. Better handling of exit codes
2. use adb shell screencap instead of UIAutomator's functionality (works on emulators as well)
